### PR TITLE
feat: socket security

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,8 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-websocket")
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("org.springframework.security:spring-security-messaging")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/src/main/kotlin/com/_up/notification_api/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/_up/notification_api/config/SecurityConfiguration.kt
@@ -1,0 +1,57 @@
+package com._up.notification_api.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.Customizer
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.provisioning.InMemoryUserDetailsManager
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfiguration {
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain =
+        http
+            .csrf { csrf -> csrf.disable() }
+            .cors { cors -> cors.configurationSource(corsConfigurationSource()) }
+            .authorizeHttpRequests { httpRequests -> httpRequests.anyRequest().hasRole("ADMIN") }
+            .httpBasic(Customizer.withDefaults())
+            .build()
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val corsConfiguration = CorsConfiguration().apply {
+            allowedOrigins = listOf("http://localhost:5173")
+            allowedMethods = listOf("*")
+            allowCredentials = true
+        }
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", corsConfiguration)
+        return source
+    }
+
+    @Bean
+    fun userDetailsService(): UserDetailsService =
+        InMemoryUserDetailsManager(
+            User.builder()
+                .username("esosa")
+                .password("{noop}12345")
+                .roles("ADMIN")
+                .build(),
+
+            User.builder()
+                .username("lmessi")
+                .password("{noop}12345")
+                .roles("USER")
+                .build()
+        )
+}


### PR DESCRIPTION
Added Spring Security to protect the websocket endpoits using Basic authentication: just a simple configuration with in-memory users was added for the role-based authentication. Also, as the websocket handshake implies some messaging between front and back clients, it was needed some CORS configuration.